### PR TITLE
Add Unicode garbled text encryptor

### DIFF
--- a/src/com/company/mojigm.java
+++ b/src/com/company/mojigm.java
@@ -1,0 +1,49 @@
+package com.company;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class mojigm {
+    public static void main(String[] args) {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        System.out.println("Enter text to encode:");
+        try {
+            String input = br.readLine();
+            br.close();
+            String encoded = encodeToUnicodeGarbled(input);
+            System.out.println(encoded);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String encodeToUnicodeGarbled(String input) {
+        byte[] hash = hashBytes(input.getBytes());
+        if (hash == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < hash.length; i += 2) {
+            int high = hash[i] & 0xFF;
+            int low = 0;
+            if (i + 1 < hash.length) {
+                low = hash[i + 1] & 0xFF;
+            }
+            int codePoint = (high << 8) | low;
+            sb.append((char) codePoint);
+        }
+        return sb.toString();
+    }
+
+    private static byte[] hashBytes(byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return digest.digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `mojigm.java` to perform SHA‑256 hashing and map the hash bytes to a Unicode string

## Testing
- `javac src/com/company/mojigm.java`
- `echo "test input" | java -cp src com.company.mojigm`


------
https://chatgpt.com/codex/tasks/task_e_687687f534648322a0d2c42a2109df74