### PR TITLE
Add Extragman with extra word mappings

### DIFF
--- a/src/com/company/Extragman.java
+++ b/src/com/company/Extragman.java
@@ -1,0 +1,59 @@
+package com.company;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Extension of {@link enigmn_fin} that introduces replacement codes for
+ * frequently used English and Japanese words. The class provides simple
+ * encode/decode helpers which run in addition to the base encryption.
+ */
+public class Extragman extends enigmn_fin {
+
+    /** Mapping from words/phrases to unique codes. */
+    private static final Map<String, String> WORD_TO_CODE = new LinkedHashMap<>();
+    /** Reverse mapping for decoding. */
+    private static final Map<String, String> CODE_TO_WORD = new LinkedHashMap<>();
+
+    static {
+        addMapping("the", "\u262D1");       // example frequent English word
+        addMapping("and", "\u262D2");
+        addMapping("to", "\u262D3");
+        addMapping("hello", "\u262D4");
+        addMapping("world", "\u262D5");
+        addMapping("こんにちは", "\u262DJ1");
+        addMapping("ありがとう", "\u262DJ2");
+    }
+
+    private static void addMapping(String word, String code) {
+        WORD_TO_CODE.put(word, code);
+        CODE_TO_WORD.put(code, word);
+    }
+
+    /**
+     * Apply extra word replacements before delegating to the base encrypt
+     * method.
+     */
+    public static String encryptExtra(String input) {
+        String work = input;
+        for (Map.Entry<String, String> e : WORD_TO_CODE.entrySet()) {
+            work = work.replace(e.getKey(), e.getValue());
+        }
+        // Delegate to the encryption from enigmn_fin
+        return encrypt(work);
+    }
+
+    /**
+     * Reverse only the replacements introduced by {@link #encryptExtra}.
+     * The original transformation performed by {@link enigmn_fin#encrypt}
+     * is not reverted here.
+     */
+    public static String decryptExtra(String input) {
+        String work = input;
+        for (Map.Entry<String, String> e : CODE_TO_WORD.entrySet()) {
+            work = work.replace(e.getKey(), e.getValue());
+        }
+        return work;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `Extragman` class to extend `enigmn_fin`
- introduce mappings for common English and Japanese words to custom codes
- provide helper methods `encryptExtra` and `decryptExtra`

## Testing
- `javac -d out src/com/company/*.java`

------
https://chatgpt.com/codex/tasks/task_e_6876890beb98832284dd9bd273779b89